### PR TITLE
Find version in container instead of using a REVISIONS file

### DIFF
--- a/appsignal_deploy.sh
+++ b/appsignal_deploy.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-version="1.0"
+version="1.1"
 
 function usage {
     echo "AWS Elastic Beanstalk Deployment Notifications for AppSignal (v${version})"
@@ -34,7 +34,8 @@ function error {
 
 api_key=""
 app_name=""
-environment=$RAILS_ENV
+app_version=""
+environment=$RACK_ENV
 deployer=""
 verbose=1
 error_on_fail=0
@@ -72,8 +73,13 @@ fi
 if [[ -f REVISION ]]; then
     app_version=$(cat REVISION)
 else
-    app_version="unknown"
-    error "Unable to extract application version from source REVISION file"
+    EB_CONFIG_SOURCE_BUNDLE=$(/opt/elasticbeanstalk/bin/get-config container -k source_bundle)
+    app_version=$(unzip -z "${EB_CONFIG_SOURCE_BUNDLE}" | tail -n1)
+
+    if [[ -z "${app_version}" ]]; then
+        app_version="unknown"
+        error "Unable to extract application version from source REVISION file, or load version information from within the container"
+    fi
 fi
 
 if [[ -z "${environment}" ]]; then

--- a/newrelic_deploy.sh
+++ b/newrelic_deploy.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-version="1.0"
+version="1.1"
 
 function usage {
     echo "AWS Elastic Beanstalk Deployment Notifications for New Relic (v${version})"
@@ -71,8 +71,13 @@ fi
 if [[ -f REVISION ]]; then
     app_version=$(cat REVISION)
 else
-    app_version="unknown"
-    error "Unable to extract application version from source REVISION file"
+    EB_CONFIG_SOURCE_BUNDLE=$(/opt/elasticbeanstalk/bin/get-config container -k source_bundle)
+    app_version=$(unzip -z "${EB_CONFIG_SOURCE_BUNDLE}" | tail -n1)
+
+    if [[ -z "${app_version}" ]]; then
+        app_version="unknown"
+        error "Unable to extract application version from source REVISION file, or load version information from within the container"
+    fi
 fi
 
 if [[ ${verbose} == 1 ]]; then


### PR DESCRIPTION
Hi there,

thanks a lot for your awesome article on http://devblog.springest.com/deploy-notifications-to-newrelic-appsignal-and-slack-with-elastic-beanstalk/

The only thing that bothered me a bit, was the fact that you should commit the current version to a REVISIONS file, which I found not optimal.

So I changed the script a bit, to support a fallback mechamism when there is no REVISIONS file; it will look inside the server container for the deploy file, which holds the current deployed version number (aka git commit hash).

Please consider this pull request, as it will remain compatible with your blog post.

Thanks again!

Kind regards,

Stijn
